### PR TITLE
Refactored constraint

### DIFF
--- a/src/deepymod/model/constraint.py
+++ b/src/deepymod/model/constraint.py
@@ -13,9 +13,7 @@ class LeastSquares(Constraint):
         """ Least Squares Constraint solved by QR decomposition"""
         super().__init__()
 
-    def calculate_coeffs(
-        self, sparse_thetas: TensorList, time_derivs: TensorList
-    ) -> TensorList:
+    def fit(self, sparse_thetas: TensorList, time_derivs: TensorList) -> TensorList:
         """Calculates the coefficients of the constraint using the QR decomposition for every pair
         of sparse feature matrix and time derivative.
 
@@ -24,20 +22,12 @@ class LeastSquares(Constraint):
             time_derivs (TensorList): List containing the time derivatives of size (n_samples, n_outputs).
 
         Returns:
-            (TensorList): Calculated coefficients of size (n_features, n_outputs).
+            (TensorList): List of calculated coefficients of size [(n_active_features, 1) x n_outputs].
         """
-        opt_coeff = []
+        coeff_vectors = []
         for theta, dt in zip(sparse_thetas, time_derivs):
             Q, R = torch.qr(theta)  # solution of lst. sq. by QR decomp.
-            opt_coeff.append(torch.inverse(R) @ Q.T @ dt)
-
-        # Putting them in the right spot
-        coeff_vectors = [
-            torch.zeros((mask.shape[0], 1))
-            .to(coeff_vector.device)
-            .masked_scatter_(mask[:, None], coeff_vector)
-            for mask, coeff_vector in zip(self.sparsity_masks, opt_coeff)
-        ]
+            coeff_vectors.append(torch.inverse(R) @ Q.T @ dt)
         return coeff_vectors
 
 
@@ -51,11 +41,11 @@ class GradParams(Constraint):
             n_eqs (int): number of outputs / equations to be discovered.
         """
         super().__init__()
-        self.coeff_vectors = torch.nn.ParameterList(
+        self.coeffs = torch.nn.ParameterList(
             [torch.nn.Parameter(torch.randn(n_params, 1)) for _ in torch.arange(n_eqs)]
         )
 
-    def calculate_coeffs(self, sparse_thetas: TensorList, time_derivs: TensorList):
+    def fit(self, sparse_thetas: TensorList, time_derivs: TensorList):
         """Returns the coefficients of the constraint, since we're optimizing them by
            gradient descent.
 
@@ -66,4 +56,4 @@ class GradParams(Constraint):
         Returns:
             (TensorList): Calculated coefficients of size (n_features, n_outputs).
         """
-        return self.coeff_vectors
+        return self.coeffs

--- a/src/deepymod/model/deepmod.py
+++ b/src/deepymod/model/deepmod.py
@@ -20,15 +20,16 @@ class Constraint(nn.Module, metaclass=ABCMeta):
         super().__init__()
         self.sparsity_masks: TensorList = None
 
-    def forward(
-        self, input: Tuple[TensorList, TensorList]
-    ) -> Tuple[TensorList, TensorList]:
-        """The forward pass of the constraint module applies the sparsity mask to the feature matrix theta,
-        and then calculates the coefficients according to the method in the child.
+    def forward(self, input: Tuple[TensorList, TensorList]) -> TensorList:
+        """The forward pass of the constraint module applies the sparsity mask to the
+        feature matrix theta, and then calculates the coefficients according to the
+        method in the child.
 
         Args:
             input (Tuple[TensorList, TensorList]): (time_derivs, library) tuple of size
                     ([(n_samples, 1) X n_outputs], [(n_samples, n_features) x n_outputs]).
+        Returns:
+            coeff_vectors (TensorList): List with coefficient vectors of size ([(n_features, 1) x n_outputs])
         """
 
         time_derivs, thetas = input
@@ -39,10 +40,23 @@ class Constraint(nn.Module, metaclass=ABCMeta):
                 for theta in thetas
             ]
 
-        sparse_thetas = self.apply_mask(thetas)
-        self.coeff_vectors = self.calculate_coeffs(sparse_thetas, time_derivs)
+        sparse_thetas = self.apply_mask(thetas, self.sparsity_masks)
+        coeff_vectors = self.fit(sparse_thetas, time_derivs)
 
-    def apply_mask(self, thetas: TensorList) -> TensorList:
+        # Constraint grad. desc style doesn't allow to change shape, so we return full coeff
+        # and multiply by mask to set zeros. For least squares-style, we need to put in
+        # zeros in the right spot to get correct shape.
+        self.coeff_vectors = [
+            self.map_coeffs(mask, coeff)
+            if mask.shape[0] != coeff.shape[0]
+            else coeff * mask[:, None]
+            for mask, coeff in zip(self.sparsity_masks, coeff_vectors)
+        ]
+
+        return self.coeff_vectors
+
+    @staticmethod
+    def apply_mask(thetas: TensorList, masks: TensorList) -> TensorList:
         """Applies the sparsity mask to the feature (library) matrix.
 
         Args:
@@ -51,16 +65,30 @@ class Constraint(nn.Module, metaclass=ABCMeta):
         Returns:
             TensorList: The sparse version of the library matrices of size [(n_samples, n_active_features) x n_outputs].
         """
-        sparse_thetas = [
-            theta[:, sparsity_mask]
-            for theta, sparsity_mask in zip(thetas, self.sparsity_masks)
-        ]
+        sparse_thetas = [theta[:, mask] for theta, mask in zip(thetas, masks)]
         return sparse_thetas
 
+    @staticmethod
+    def map_coeffs(mask: torch.Tensor, coeff_vector: torch.Tensor) -> torch.Tensor:
+        """ Places the coeff_vector components in the true positions of the mask.
+        I.e. maps ((0, 1, 1, 0), (0.5, 1.5)) -> (0, 0.5, 1.5, 0).
+
+        Args:
+            mask (torch.Tensor): Boolean mask describing active components.
+            coeff_vector (torch.Tensor): Vector with active-components.
+
+        Returns:
+            mapped_coeffs (torch.Tensor): mapped coefficients.
+        """
+        mapped_coeffs = (
+            torch.zeros((mask.shape[0], 1))
+            .to(coeff_vector.device)
+            .masked_scatter_(mask[:, None], coeff_vector)
+        )
+        return mapped_coeffs
+
     @abstractmethod
-    def calculate_coeffs(
-        self, sparse_thetas: TensorList, time_derivs: TensorList
-    ) -> TensorList:
+    def fit(self, sparse_thetas: TensorList, time_derivs: TensorList) -> TensorList:
         """Abstract method. Specific method should return the coefficients as calculated from the sparse feature
         matrices and temporal derivatives.
 
@@ -69,9 +97,9 @@ class Constraint(nn.Module, metaclass=ABCMeta):
             time_derivs (TensorList): List containing the time derivatives of size (n_samples, n_outputs).
 
         Returns:
-            (TensorList): Calculated coefficients of size (n_features, n_outputs).
+            (TensorList): Calculated coefficients of size (n_active_features, n_outputs).
         """
-        pass
+        raise NotImplementedError
 
 
 class Estimator(nn.Module, metaclass=ABCMeta):
@@ -219,7 +247,7 @@ class DeepMoD(nn.Module):
         """
         prediction, coordinates = self.func_approx(input)
         time_derivs, thetas = self.library((prediction, coordinates))
-        self.constraint((time_derivs, thetas))
+        coeff_vectors = self.constraint((time_derivs, thetas))
         return prediction, time_derivs, thetas
 
     @property

--- a/src/deepymod/model/deepmod.py
+++ b/src/deepymod/model/deepmod.py
@@ -70,7 +70,7 @@ class Constraint(nn.Module, metaclass=ABCMeta):
 
     @staticmethod
     def map_coeffs(mask: torch.Tensor, coeff_vector: torch.Tensor) -> torch.Tensor:
-        """ Places the coeff_vector components in the true positions of the mask.
+        """Places the coeff_vector components in the true positions of the mask.
         I.e. maps ((0, 1, 1, 0), (0.5, 1.5)) -> (0, 0.5, 1.5, 0).
 
         Args:

--- a/src/deepymod/model/deepmod.py
+++ b/src/deepymod/model/deepmod.py
@@ -41,11 +41,11 @@ class Constraint(nn.Module, metaclass=ABCMeta):
             ]
 
         sparse_thetas = self.apply_mask(thetas, self.sparsity_masks)
-        coeff_vectors = self.fit(sparse_thetas, time_derivs)
 
         # Constraint grad. desc style doesn't allow to change shape, so we return full coeff
         # and multiply by mask to set zeros. For least squares-style, we need to put in
         # zeros in the right spot to get correct shape.
+        coeff_vectors = self.fit(sparse_thetas, time_derivs)
         self.coeff_vectors = [
             self.map_coeffs(mask, coeff)
             if mask.shape[0] != coeff.shape[0]


### PR DESCRIPTION
Hi all, 

I've worked on #36, simplifying the constraint a bit. I've basically done the following:
- **Placing the non-zero terms in the right place now happens in the abstract baseclass**. The operation mapping the coeffs (0.5, 1.3) with mask (0, 1, 1, 0) -> (0, 0.5, 1.3, 0) is now done in the baseclass. This makes implementing a constraint simpler, because previously necessary op now happens automatically. It also means the output is consistent (theta (n x m) in, coefficient (m x 1) out.) and that your specific constraint is independent of the underlying mask and baseclass, making it much easier to (unit-) test.

- **Added a method mapp_coeffs to the abstract baseclass**. See point above; for clarity I implemented this in a separate function.

- **Renamed calculate_coeffs to fit**, to bring it in line with the estimator class.

- **Forward now returns coefficients**. Forward should always return something, even if we don't use it. 

I've tested it using the least squares and gradient constraint, both work. Am submitting a PR for ridge regression shortly.